### PR TITLE
Updated version and meter information.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This meter plugin collects metrics from the ActiveMQ node using the embedded [Jo
 |:----------|:-----:|:-------:|:-------:|:----:|
 | Supported |   v   |    v    |    v    |  v   |
 
-#### TrueSight Pulse Meter Versions V4.2 or later
+This plugin is compatible with ActiveMQ 5.10.0 or later.
+
+#### TrueSight Pulse Meter Versions V4.5.0-778 or later
 
 - To install new meter go to Settings->Installation or [see instructons|https://help.boundary.com/hc/en-us/sections/200634331-Installation].
 - To upgrade the meter to the latest version - [see instructons|https://help.boundary.com/hc/en-us/articles/201573102-Upgrading-the-Boundary-Meter].


### PR DESCRIPTION
Require meter 4.5.0.-778 or later. Supports only ActiveMQ 5.10.0 and later.